### PR TITLE
Fix issue where expanding group would call incorrect overloaded 'expand' and 'collapse' methods.

### DIFF
--- a/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/viewholders/GroupViewHolder.java
+++ b/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/viewholders/GroupViewHolder.java
@@ -25,7 +25,7 @@ public abstract class GroupViewHolder extends RecyclerView.ViewHolder implements
   @Override
   public void onClick(View v) {
     if (listener != null) {
-      if (listener.onGroupClick(getAdapterPosition())) {
+      if (!listener.onGroupClick(getAdapterPosition())) {
         expand();
       } else {
         collapse();


### PR DESCRIPTION
When a group was clicked the incorrect method was called for the action. 