### PR TITLE
Fix Issue #14

### DIFF
--- a/expandablecheckrecyclerview/src/main/java/com/thoughtbot/expandablecheckrecyclerview/CheckableChildRecyclerViewAdapter.java
+++ b/expandablecheckrecyclerview/src/main/java/com/thoughtbot/expandablecheckrecyclerview/CheckableChildRecyclerViewAdapter.java
@@ -15,6 +15,7 @@ import com.thoughtbot.expandablerecyclerview.models.ExpandableGroup;
 import com.thoughtbot.expandablerecyclerview.models.ExpandableListPosition;
 import com.thoughtbot.expandablerecyclerview.viewholders.GroupViewHolder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class CheckableChildRecyclerViewAdapter<GVH extends GroupViewHolder, CCVH extends CheckableChildViewHolder>
@@ -79,8 +80,7 @@ public abstract class CheckableChildRecyclerViewAdapter<GVH extends GroupViewHol
    */
   @Override
   public void onSaveInstanceState(Bundle outState) {
-    outState.putParcelableArrayList(CHECKED_STATE_MAP,
-        (ArrayList<? extends Parcelable>) expandableList.groups);
+    outState.putParcelableArrayList(CHECKED_STATE_MAP, new ArrayList(expandableList.groups));
     super.onSaveInstanceState(outState);
   }
 

--- a/sample/src/main/java/com/thoughtbot/expandablerecyclerview/sample/multitypeandcheck/MultiTypeCheckGenreAdapter.java
+++ b/sample/src/main/java/com/thoughtbot/expandablerecyclerview/sample/multitypeandcheck/MultiTypeCheckGenreAdapter.java
@@ -105,8 +105,7 @@ public class MultiTypeCheckGenreAdapter
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
-    outState.putParcelableArrayList(CHECKED_STATE_MAP,
-        (ArrayList<? extends Parcelable>) expandableList.groups);
+    outState.putParcelableArrayList(CHECKED_STATE_MAP, new ArrayList(expandableList.groups));
     super.onSaveInstanceState(outState);
   }
 


### PR DESCRIPTION
## 🔧 changes

`Arrays.asList` returns a `List` implementation, but it's not a `java.util.ArrayList`. It happens to have a classname of `ArrayList`, but that's a nested class within `Arrays` - a completely different type from `java.util.ArrayList`. Since we need a `java.util.ArrayList`, we are simply creating a copy.
## 📝 issue
#14
