### PR TITLE
Properly deserialize expandable group from Parcel

### DIFF
--- a/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
+++ b/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
@@ -39,8 +39,9 @@ public class ExpandableGroup<T extends Parcelable> implements Parcelable {
 
   protected ExpandableGroup(Parcel in) {
     title = in.readString();
-    if (in.readByte() == 0x01) {
-      int size = in.readInt();
+    byte hasItems = in.readByte();
+    int size = in.readInt();
+    if (hasItems == 0x01) {
       items = new ArrayList<T>(size);
       Class<?> type = (Class<?>) in.readSerializable();
       in.readList(items, type.getClassLoader());


### PR DESCRIPTION
## 🔧 changes
- Update deserialization from Parcel method in `ExpandableGroup` to make writing / reading from parcel consistent

## 🏁 fixes issue:
#20 