### PR TITLE
Update ExpandableGroup.java

### DIFF
--- a/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
+++ b/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * The backing data object for an {@link ExpandableGroup}
  */
-public class ExpandableGroup<T extends Parcelable> implements Parcelable {
+public class ExpandableGroup<T> implements Parcelable {
   private String title;
   private List<T> items;
 


### PR DESCRIPTION
for this class "ExpandableGroup.java" by replacing the tag `<T` extends `Parcelable>` with `<T>` , we can use parcelable and serializable data models.