### PR TITLE
Patch for writeToParcel() at ExpandableGroup fatal exception

### DIFF
--- a/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
+++ b/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
@@ -64,8 +64,10 @@ public class ExpandableGroup<T extends Parcelable> implements Parcelable {
     } else {
       dest.writeByte((byte) (0x01));
       dest.writeInt(items.size());
-      final Class<?> objectsType = items.get(0).getClass();
-      dest.writeSerializable(objectsType);
+      if (items.size() > 0) {
+          final Class<?> objectsType = items.get(0).getClass();
+          dest.writeSerializable(objectsType);
+      }
       dest.writeList(items);
     }
   }

--- a/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
+++ b/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
@@ -64,8 +64,10 @@ public class ExpandableGroup<T extends Parcelable> implements Parcelable {
     } else {
       dest.writeByte((byte) (0x01));
       dest.writeInt(items.size());
-      final Class<?> objectsType = items.get(0).getClass();
-      dest.writeSerializable(objectsType);
+      if (items.size() > 0) {
+        final Class<?> objectsType = items.get(0).getClass();
+        dest.writeSerializable(objectsType);
+      }
       dest.writeList(items);
     }
   }

--- a/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
+++ b/expandablerecyclerview/src/main/java/com/thoughtbot/expandablerecyclerview/models/ExpandableGroup.java
@@ -64,10 +64,8 @@ public class ExpandableGroup<T extends Parcelable> implements Parcelable {
     } else {
       dest.writeByte((byte) (0x01));
       dest.writeInt(items.size());
-      if (items.size() > 0) {
-          final Class<?> objectsType = items.get(0).getClass();
-          dest.writeSerializable(objectsType);
-      }
+      final Class<?> objectsType = items.get(0).getClass();
+      dest.writeSerializable(objectsType);
       dest.writeList(items);
     }
   }


### PR DESCRIPTION
This problem is mentioned in #104 and #44, the root of the problem was in `items.get(0)` call on an empty collection