### PR TITLE
Deprecated expandable-recycler-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Deprecated as of September 20, 2024
+
+expandable-recycler-view is no longer maintained. If you wish to continue to develop this code yourself, we recommend you fork it.
+
 ![logo](https://images.thoughtbot.com/blog-vellum-image-uploads/lpMtQDMlRindAIJOHlGl_expandable-recycler-view-logo.png)
 
 # Expandable RecyclerView [![CircleCI](https://circleci.com/gh/thoughtbot/expandable-recycler-view/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/expandable-recycler-view/tree/master)


### PR DESCRIPTION
We no longer use this library in our client projects. We recommend forking this library and keep it up date, if you still wish to use it.